### PR TITLE
Clean up `http.ListenAndServe`

### DIFF
--- a/main.go
+++ b/main.go
@@ -127,8 +127,7 @@ func main() {
 	fmt.Println()
 	fmt.Printf("==> Server listening at %s 🚀\n", bindAddr)
 
-	err := http.ListenAndServe(bindAddr, nil)
-	if err != nil {
+	if err := http.ListenAndServe(bindAddr, nil); err != nil {
 		panic(err)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -127,7 +127,7 @@ func main() {
 	fmt.Println()
 	fmt.Printf("==> Server listening at %s 🚀\n", bindAddr)
 
-	err := http.ListenAndServe(fmt.Sprintf(":%s", port), nil)
+	err := http.ListenAndServe(bindAddr, nil)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This PR cleans up the `http.ListenAndServe` if statement by removing the redundant `Sprintf` call, it's already available from earlier in `main`. So no need to duplicate it again.
https://github.com/digitalocean/sample-golang/blob/0033b3f954ea06f154807969405a2388db74551b/main.go#L121

Also simplified the if statement more by taking advantage of Go's ability to initialize local variables inside [if statements](https://go.dev/doc/effective_go#if).