### PR TITLE
Sorting output of /env handler

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -84,8 +85,8 @@ func main() {
 			fmt.Fprint(w, os.Getenv(keys[0]))
 			return
 		}
-		envs := []string{}
-		envs = append(envs, os.Environ()...)
+		envs := os.Environ()
+		sort.Strings(envs)
 		fmt.Fprint(w, strings.Join(envs, "\n"))
 	})
 


### PR DESCRIPTION
In my humble opinion sorted variables are more readable.

By the way, `envs = append(envs, os.Environ()...)` seems useless, `os.Environ()` does the trick for you (it calls [`syscall.Environ()`](https://cs.opensource.google/go/go/+/refs/tags/go1.21.5:src/syscall/env_unix.go;l=139))