### PR TITLE
Minor improvements: modern methods, less panic-prone

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/digitalocean/sample-golang
 
-go 1.13
+go 1.18
 
 require github.com/gofrs/uuid v3.3.0+incompatible // indirect


### PR DESCRIPTION
Minor code update:
- Using `r.URL.Query().Get("...")` instead of `r.URL.Query()["..."]` where this is the case
- Using modern `strings.Cut` instead of `strings.SplitN(..., 2)`
- Bumping required go version up to 1.18 to enable `strings.Cut` using
- Fixing panic-prone code `w.Header().Set(h[0], strings.TrimSpace(h[1]))`, where `h` can have arbitrary length